### PR TITLE
Feature/styleguide rules

### DIFF
--- a/tslint.json
+++ b/tslint.json
@@ -196,6 +196,18 @@
     "use-life-cycle-interface": true,
     "use-pipe-transform-interface": true,
     "component-class-suffix": true,
-    "directive-class-suffix": true
+    "directive-class-suffix": true,
+    "trailing-comma": [
+      true,
+      {
+        "multiline": {
+          "objects": "always",
+          "arrays": "always",
+          "imports": "always",
+          "functions": "never"
+        },
+        "esSpecCompliant": true
+      }
+    ]
   }
 }

--- a/tslint.json
+++ b/tslint.json
@@ -8,7 +8,8 @@
     "class-name": true,
     "comment-format": [
       true,
-      "check-space"
+      "check-space",
+      "check-uppercase"
     ],
     "curly": true,
     "deprecation": {

--- a/tslint.json
+++ b/tslint.json
@@ -34,12 +34,7 @@
       true,
       140
     ],
-    "member-access": [
-      true,
-      "check-accessor",
-      "check-constructor",
-      "check-parameter-property"
-    ],
+    "member-access": true,
     "typedef": [
       true,
       "call-signature",


### PR DESCRIPTION
I made some adjustments to the ruleset to be consistent with our style guide:

- Force single-lined comments to start with an upper case letter
- Force specifying "public" access modifier
- Require to end multiline import, object and array declarations with a comma