### PR TITLE
Forbid multiple consecutive newline symbols

### DIFF
--- a/tslint.json
+++ b/tslint.json
@@ -133,6 +133,7 @@
       "check-else",
       "check-whitespace"
     ],
+    "no-consecutive-blank-lines": true,
     "prefer-const": true,
     "quotemark": [
       true,


### PR DESCRIPTION
This is just a small change I'd like to see which will not allow several consecutive empty lines to be present in a code.