### PR TITLE
Allow setting trailing commas for constructor declarations

### DIFF
--- a/tslint.json
+++ b/tslint.json
@@ -197,12 +197,7 @@
     "trailing-comma": [
       true,
       {
-        "multiline": {
-          "objects": "always",
-          "arrays": "always",
-          "imports": "always",
-          "functions": "ignore"
-        },
+        "multiline": "always",
         "esSpecCompliant": true
       }
     ]

--- a/tslint.json
+++ b/tslint.json
@@ -201,7 +201,7 @@
           "objects": "always",
           "arrays": "always",
           "imports": "always",
-          "functions": "never"
+          "functions": "ignore"
         },
         "esSpecCompliant": true
       }


### PR DESCRIPTION
We have a rule in our style guide to also append trailing comma in a constructor declaration.
As I see, there is no way for enforcing this rule at the moment so we'll just allow to append trailing commas for all functions.