### PR TITLE
Allow importing from rxjs module

### DIFF
--- a/tslint.json
+++ b/tslint.json
@@ -19,7 +19,6 @@
     "forin": true,
     "import-blacklist": [
       true,
-      "rxjs",
       "rxjs/Rx"
     ],
     "import-spacing": true,


### PR DESCRIPTION
With rxjs 6+ we need ability to import from 'rxjs' module itself. I guess, this can be later configured per project if necessary.