### PR TITLE
Lowercase inheritdoc

### DIFF
--- a/tslint.json
+++ b/tslint.json
@@ -153,7 +153,6 @@
         "variable-declaration": "nospace"
       }
     ],
-    "typeof-compare": true,
     "unified-signatures": true,
     "variable-name": false,
     "whitespace": [

--- a/tslint.json
+++ b/tslint.json
@@ -47,7 +47,7 @@
           "visibilities": ["exported"],
           "tags": {
             "content": {},
-            "existence": ["inheritDoc"]
+            "existence": ["inheritDoc", "inheritdoc"]
           }
         },
         "enums": true,
@@ -59,21 +59,21 @@
           "visibilities": ["exported"],
           "tags": {
             "content": {},
-            "existence": ["inheritDoc"]
+            "existence": ["inheritDoc", "inheritdoc"]
           }
         },
         "methods": {
           "privacies": ["public", "protected"],
           "tags": {
             "content": {},
-            "existence": ["inheritDoc"]
+            "existence": ["inheritDoc", "inheritdoc"]
           }
         },
         "properties": {
           "privacies": ["public", "protected"],
           "tags": {
             "content": {},
-            "existence": ["inheritDoc"]
+            "existence": ["inheritDoc", "inheritdoc"]
           }
         }
       }


### PR DESCRIPTION
1. Allow entering all lowercase "inheritdoc" for JSDoc comments
2. Remove "typeof-compare" rule because it's redundant for Typescript 2.2+